### PR TITLE
Use unsigned intergers for AP/RAP/Armor formatting. Also add missing ruRU translation strings.

### DIFF
--- a/src/attributes/agility.tl
+++ b/src/attributes/agility.tl
@@ -215,7 +215,7 @@ function getBonusesString(agility: number): string
     if (config["Agility-AP"]) then
         local apFromAgi = getAPFromAgi(modifiedAgility, playerClass);
         if (apFromAgi > 0) then            
-            local apString = format("%.1F", apFromAgi) .. " " .. _locale.StatStrings.AttackPower;
+            local apString = format("%u", apFromAgi) .. " " .. _locale.StatStrings.AttackPower;
             table.insert(statStrings, apString);
         end
     end
@@ -224,7 +224,7 @@ function getBonusesString(agility: number): string
     if(config["Agility-RAP"]) then
         local rapFromAgi = getRAPFromAgi(modifiedAgility, playerClass);
         if rapFromAgi > 0 then
-            local rapString = format("%.1F", rapFromAgi).. " " .. _locale.StatStrings.RangedAttackPower;
+            local rapString = format("%u", rapFromAgi).. " " .. _locale.StatStrings.RangedAttackPower;
             table.insert(statStrings, rapString);
         end
     end
@@ -233,7 +233,7 @@ function getBonusesString(agility: number): string
     if(config["Agility-Armor"]) then
         local armorFromAgi = getArmorFromAgi(modifiedAgility);
         if (armorFromAgi > 0) then
-            local armorString = format("%.1F ", armorFromAgi).._locale.StatStrings.Armor;
+            local armorString = format("%u ", armorFromAgi).._locale.StatStrings.Armor;
             table.insert(statStrings, armorString);
         end
     end

--- a/src/strings/strings.ruRU.tl
+++ b/src/strings/strings.ruRU.tl
@@ -137,16 +137,16 @@ ruRU.ConfigStrings ={
     AgiDodgeCheck = "бонус к уклонению",
     AgiCritCheck = "бонус к критическому попаданию",
     AgiArmorCheck = "бонус к броне",
-    AgiAPCheck = "бонус к силе атаки (СА)",
-    AgiRAPCheck = "бонус к силе атаки дальнего боя (САДБ)",
+    AgiAPCheck = "бонус к силе атаки (AP)",
+    AgiRAPCheck = "бонус к силе атаки дальнего боя (RAP)",
 };
 
 -- These are used to localize text injected into tooltips (mostly used for breaking down things like Agility and Intellect).
 ruRU.StatStrings = {
     Dodge = "уклон.",
     Crit = "крит.",
-    AttackPower = "СА",
-    RangedAttackPower = "САДБ",
+    AttackPower = "AP", -- use english well-established abbreviation for AttackPower
+    RangedAttackPower = "RAP", -- and for RangedAttackPower
     Armor = "брони",
 }
 

--- a/src/strings/strings.ruRU.tl
+++ b/src/strings/strings.ruRU.tl
@@ -132,22 +132,22 @@ ruRU.ConfigStrings ={
     PhysicalHasteRatingCheckbox = "Конвертировать рейтинг скорости",
     PhysicalExpertiseRatingCheckbox = "Конвертировать рейтинг мастерства",
 
-    AttributesHeader = "Attributes",
-    AgilityCheckbox = "Scan for Agility and...",
-    AgiDodgeCheck = "...display Dodge bonus",
-    AgiCritCheck = "...display Crit bonus",
-    AgiArmorCheck = "...display Armor bonus",
-    AgiAPCheck = "...display Attack Power bonus",
-    AgiRAPCheck = "...display Ranged Attack Power bonus",
+    AttributesHeader = "Характеристики",
+    AgilityCheckbox = "Конвертировать ловкость",
+    AgiDodgeCheck = "бонус к уклонению",
+    AgiCritCheck = "бонус к критическому попаданию",
+    AgiArmorCheck = "бонус к броне",
+    AgiAPCheck = "бонус к силе атаки (СА)",
+    AgiRAPCheck = "бонус к силе атаки дальнего боя (САДБ)",
 };
 
 -- These are used to localize text injected into tooltips (mostly used for breaking down things like Agility and Intellect).
 ruRU.StatStrings = {
-    Dodge = "Dodge",
-    Crit = "Crit",
-    AttackPower = "AP",
-    RangedAttackPower = "RAP",
-    Armor = "Armor",
+    Dodge = "уклон.",
+    Crit = "крит.",
+    AttackPower = "СА",
+    RangedAttackPower = "САДБ",
+    Armor = "брони",
 }
 
 LB.LocaleTables["ruRU"] = {};


### PR DESCRIPTION
IMHO, it looks a bit better, when AP and Armor are displayed without floating point. Also add translation strings for agility conversions. I used english "AP" and "RAP" abbreviations, since most of the users I told to, think it looks better that translated versions.